### PR TITLE
Add a CMake based build for linux

### DIFF
--- a/SymmThinningCUDA/SymmThinningCUDA/.gitignore
+++ b/SymmThinningCUDA/SymmThinningCUDA/.gitignore
@@ -3,3 +3,4 @@ CMakeCache.txt
 Makefile
 *.cmake
 *.a
+main

--- a/SymmThinningCUDA/SymmThinningCUDA/.gitignore
+++ b/SymmThinningCUDA/SymmThinningCUDA/.gitignore
@@ -1,0 +1,5 @@
+CMakeFiles
+CMakeCache.txt
+Makefile
+*.cmake
+*.a

--- a/SymmThinningCUDA/SymmThinningCUDA/CMakeLists.txt
+++ b/SymmThinningCUDA/SymmThinningCUDA/CMakeLists.txt
@@ -26,6 +26,13 @@ target_link_libraries(main io_shared) # WARNING! CMake is failing to detect chan
 
 target_link_libraries(main "-L${HDF5_ROOT}/lib -lhdf5 -lhdf5_cpp -lhdf5_hl")
 
+# Failed attempt to build everything statically.
+#find_library(HDF5_LIB libhdf5.a)
+#find_library(HDF5_CPP_LIB libhdf5_cpp.a)
+#find_library(HDF5_CPP_HL libhdf5_hl.a)
+#target_link_libraries(main "-L${HDF5_ROOT}/lib ${HDF5_LIB} ${HDF5_CPP_LIB} ${HDF5_CPP_HL}")
+#target_link_libraries(main "-static")
+
 
 target_compile_features(main PUBLIC cxx_std_11)
 set_property(TARGET main PROPERTY CUDA_SEPARABLE_COMPILATION ON)

--- a/SymmThinningCUDA/SymmThinningCUDA/CMakeLists.txt
+++ b/SymmThinningCUDA/SymmThinningCUDA/CMakeLists.txt
@@ -22,6 +22,10 @@ add_subdirectory(libs)
 add_executable(main main.cu)
 target_link_libraries(main skeletonize)
 
-target_link_libraries(main io_shared)
+target_link_libraries(main io_shared) # WARNING! CMake is failing to detect changes to this dependency!! make clean!
+
+target_link_libraries(main "-L${HDF5_ROOT}/lib -lhdf5 -lhdf5_cpp -lhdf5_hl")
+
+
 target_compile_features(main PUBLIC cxx_std_11)
 set_property(TARGET main PROPERTY CUDA_SEPARABLE_COMPILATION ON)

--- a/SymmThinningCUDA/SymmThinningCUDA/CMakeLists.txt
+++ b/SymmThinningCUDA/SymmThinningCUDA/CMakeLists.txt
@@ -1,26 +1,27 @@
 cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
 project(skeletonization LANGUAGES CXX CUDA)
 
+# For compiling against a libhdf5 compiled from source from:
+# https://bitbucket.hdfgroup.org/scm/hdffv/hdf5.git
+# commit e6545faa5699aae4d5dca23ed40e3080fa9dc72d
 set(HDF5_ROOT "/usr/local/HDF_Group/HDF5/1.11.4")
+
+# For compiling against an hdf5 installed by miniconda
+#set(CONDA_ROOT "$ENV{HOME}/miniconda3" CACHE STRING "Location of the conda installation" FORCE)
+#target_include_directories(main PRIVATE ${CONDA_ROOT}/include/)
+#target_link_libraries(main -L${CONDA_ROOT}/lib)
+
 include_directories(io_shared PRIVATE "${HDF5_ROOT}/include/")
 include_directories(include)
 include_directories(libs) # for h5_io.h. HDF5 10.2 DOESN't work.
 
-
-set(CONDA_ROOT "$ENV{HOME}/miniconda3" CACHE STRING "Location of the conda installation" FORCE)
 
 add_subdirectory(src)
 add_subdirectory(libs)
 
 add_executable(main main.cu)
 target_link_libraries(main skeletonize)
-#target_include_directories(main PRIVATE ${CONDA_ROOT}/include/)
-#target_link_libraries(main -L${CONDA_ROOT}/lib)
+
 target_link_libraries(main io_shared)
 target_compile_features(main PUBLIC cxx_std_11)
-
-
-
 set_property(TARGET main PROPERTY CUDA_SEPARABLE_COMPILATION ON)
-
-#target_compile_features(main PUBLIC cxx_std_11)

--- a/SymmThinningCUDA/SymmThinningCUDA/CMakeLists.txt
+++ b/SymmThinningCUDA/SymmThinningCUDA/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
 project(skeletonization LANGUAGES CXX CUDA)
 
+set(HDF5_ROOT "/usr/local/HDF_Group/HDF5/1.11.4")
+include_directories(io_shared PRIVATE "${HDF5_ROOT}/include/")
 include_directories(include)
 include_directories(libs) # for h5_io.h. HDF5 10.2 DOESN't work.
 
@@ -8,14 +10,14 @@ include_directories(libs) # for h5_io.h. HDF5 10.2 DOESN't work.
 set(CONDA_ROOT "$ENV{HOME}/miniconda3" CACHE STRING "Location of the conda installation" FORCE)
 
 add_subdirectory(src)
+add_subdirectory(libs)
 
 add_executable(main main.cu)
 target_link_libraries(main skeletonize)
 #target_include_directories(main PRIVATE ${CONDA_ROOT}/include/)
 #target_link_libraries(main -L${CONDA_ROOT}/lib)
-set(HDF5_ROOT "/usr/local/HDF_Group/HDF5/1.11.4")
-include_directories(main PRIVATE "${HDF5_ROOT}/include/")
-target_link_libraries(main -L${HDF5_ROOT}/lib -lhdf5)
+target_link_libraries(main io_shared)
+target_compile_features(main PUBLIC cxx_std_11)
 
 
 

--- a/SymmThinningCUDA/SymmThinningCUDA/CMakeLists.txt
+++ b/SymmThinningCUDA/SymmThinningCUDA/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
+project(skeletonization LANGUAGES CXX CUDA)
+
+include_directories(include)
+include_directories(libs) # for h5_io.h. HDF5 10.2 DOESN't work.
+
+
+set(CONDA_ROOT "$ENV{HOME}/miniconda3" CACHE STRING "Location of the conda installation" FORCE)
+
+add_subdirectory(src)
+
+add_executable(main main.cu)
+target_link_libraries(main skeletonize)
+#target_include_directories(main PRIVATE ${CONDA_ROOT}/include/)
+#target_link_libraries(main -L${CONDA_ROOT}/lib)
+set(HDF5_ROOT "/usr/local/HDF_Group/HDF5/1.11.4")
+include_directories(main PRIVATE "${HDF5_ROOT}/include/")
+target_link_libraries(main -L${HDF5_ROOT}/lib -lhdf5)
+
+
+
+set_property(TARGET main PROPERTY CUDA_SEPARABLE_COMPILATION ON)
+
+#target_compile_features(main PUBLIC cxx_std_11)

--- a/SymmThinningCUDA/SymmThinningCUDA/include/clique.cuh
+++ b/SymmThinningCUDA/SymmThinningCUDA/include/clique.cuh
@@ -10,10 +10,10 @@
 #include <vector>
 #include <algorithm>					// std::sort
 
-#include <thrust\execution_policy.h>	// thrust::device
-#include <thrust\scan.h>				// thrust::exclusive_scan
-#include <thrust\count.h>				// thrust::count_if
-#include <thrust\reduce.h>				// thrust::reduce
+#include <thrust/execution_policy.h>	// thrust::device
+#include <thrust/scan.h>				// thrust::exclusive_scan
+#include <thrust/count.h>				// thrust::count_if
+#include <thrust/reduce.h>				// thrust::reduce
 
 #include "cuda_includes.h"
 #include "thinning_base.cuh"

--- a/SymmThinningCUDA/SymmThinningCUDA/libs/CMakeLists.txt
+++ b/SymmThinningCUDA/SymmThinningCUDA/libs/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_library(io_shared STATIC io_shared.cpp)
-target_link_libraries(io_shared "-L${HDF5_ROOT}/lib -lhdf5 -lhdf5_cpp -lhdf5_hl")
+#target_link_libraries(io_shared "-L${HDF5_ROOT}/lib -lhdf5 -lhdf5_cpp -lhdf5_hl")
 target_link_libraries(io_shared -lboost_system -lboost_filesystem)

--- a/SymmThinningCUDA/SymmThinningCUDA/libs/CMakeLists.txt
+++ b/SymmThinningCUDA/SymmThinningCUDA/libs/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_library(io_shared STATIC io_shared.cpp)
+target_link_libraries(io_shared "-L${HDF5_ROOT}/lib -lhdf5 -lhdf5_cpp -lhdf5_hl")
+target_link_libraries(io_shared -lboost_system -lboost_filesystem)

--- a/SymmThinningCUDA/SymmThinningCUDA/libs/h5_io.h
+++ b/SymmThinningCUDA/SymmThinningCUDA/libs/h5_io.h
@@ -419,7 +419,7 @@ namespace h5_io
 			}
 			catch( DataSetIException error )
 			{
-				error.printError();
+				error.printErrorStack();
 			}
 			// To save us the trouble from detecting whether a dataset exists,
 			// For empty slice, we let the dimension to be 1x1.
@@ -507,7 +507,7 @@ namespace h5_io
 			}
 			catch( DataSetIException error )
 			{
-				error.printError();
+				error.printErrorStack();
 
 			}
 			dataset.write(tmpDataVec.data(), datatype);

--- a/SymmThinningCUDA/SymmThinningCUDA/libs/h5_io.h
+++ b/SymmThinningCUDA/SymmThinningCUDA/libs/h5_io.h
@@ -45,7 +45,7 @@ namespace h5_io
 			m_loadChunkRangeMap.clear();
 
 			std::stringstream ss;
-			ss << m_oldGroupname << "\\" << m_chunkRangeFilename;
+			ss << m_oldGroupname << "/" << m_chunkRangeFilename;
 			
 			std::ifstream fh(ss.str());
 			std::string line;
@@ -56,8 +56,15 @@ namespace h5_io
 				lss >> lo >> hi;
 				m_loadChunkRangeMap.push_back(std::make_pair(lo, hi));
 			}
+      
+      if(m_loadChunkRangeMap.size()>0)
+      {
+        m_originalNumSlices = m_loadChunkRangeMap.back().second;
+      } else {
+        std::cout << "Error! m_loadChunkRangeMap vector is empty!" << std::endl;
+        exit(EXIT_FAILURE);
+      }
 
-			m_originalNumSlices = m_loadChunkRangeMap.back().second;
 		}
         
         class Iterator;
@@ -371,7 +378,7 @@ namespace h5_io
 		std::string _getH5Filename(const std::string& group, unsigned chunk) const
 		{
 			std::stringstream ss;
-			ss << group << "\\" << m_filePrefix << chunk << ".h5";
+			ss << group << "/" << m_filePrefix << chunk << ".h5";
 			return ss.str();
 		}
 
@@ -395,7 +402,7 @@ namespace h5_io
 			}
 
 			std::stringstream ss;
-			ss << m_newGroupname << "\\" << m_chunkRangeFilename;
+			ss << m_newGroupname << "/" << m_chunkRangeFilename;
 			std::string filename(ss.str());
 
 			std::ofstream fh(filename);

--- a/SymmThinningCUDA/SymmThinningCUDA/src/CMakeLists.txt
+++ b/SymmThinningCUDA/SymmThinningCUDA/src/CMakeLists.txt
@@ -1,0 +1,11 @@
+
+add_library(skeletonize STATIC attachment.cu  
+	neighbor.cu  
+	thinning.cu  
+	clique.cu  
+	thinning_details.cu)
+target_compile_features(skeletonize PUBLIC cxx_std_11)
+set_property(TARGET skeletonize PROPERTY CUDA_SEPARABLE_COMPILATION ON)
+
+
+


### PR DESCRIPTION
As a first step to trying out your skeletonization code, we ported it to linux! The included example builds and runs, but we haven't taken it further yet. It could be it is silently computing something totally wrong in the Linux build. Compiled on Ubuntu 14.

The CMake based build needs to be fixed up for Windows, but is at least a start for a cross-platform build. 

I didn't touch the VS project files, but it's likely some paths need updating in the VS file.

Cheers,
Andrew
Robovision